### PR TITLE
include Zenodo DOI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ $ pip install -r requirements.txt
 
 See our documentation [here](https://m6anet.readthedocs.io/)!
 
+### Citing m6Anet 
+
+If you use m6Anet in your research, please use the following DOI for citation:
+
+[![DOI](https://zenodo.org/badge/281866292.svg)](https://zenodo.org/badge/latestdoi/281866292)
+
+Christopher Hendra, & Yuk Kei Wan. (2021, April 15). GoekeLab/m6anet: Pre-release (Version Pre-release). Zenodo. http://doi.org/10.5281/zenodo.4692776
+
 ### Contributors
 
 This package is developed and maintaned by [Christopher Hendra](https://github.com/chrishendra93) and [Jonathan Göke](https://github.com/jonathangoeke). If you want to contribute, please leave an issue. Thank you.


### PR DESCRIPTION
- updated the README to include the Zenodo DOI for the pre-release (https://zenodo.org/record/4692776#.YHkh5nUzaVU)