### PR TITLE
fix issue with twine upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 m6anet is a python tool that leverages Multiple Instance Learning framework to detect m6a modifications from Nanopore Direct RNA Sequencing data
 
-### Table of Contents
+# Table of Contents
 - **[Running m6Anet](#running-m6anet)**<br>
     - **[Installation](#installation)**<br>
     - **[Dataprep](#dataprep)**<br>
@@ -299,4 +299,3 @@ This package is developed and maintaned by [Christopher Hendra](https://github.c
 
 # License
 m6Anet is licensed under the terms of the MIT license.
-

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     license="MIT",
     description='m6anet is a python package for detection of m6a modifications from Nanopore direct RNA sequencing data.',
     version=__version__,
+    long_description_content_type="text/markdown",
     long_description=README,
     url='https://github.com/GoekeLab/m6anet',
     packages=find_packages(),


### PR DESCRIPTION
Twine upload failed previously due to indentation in markdown caused by setup.py not having long_description_content as markdown file. Fixing this by including such line to setup.py